### PR TITLE
Implementing nGPT integration with fine-grained MoE

### DIFF
--- a/lizrd/core/test_llm.py
+++ b/lizrd/core/test_llm.py
@@ -1,6 +1,7 @@
 import torch
 
 from lizrd.core import llm
+import argparse
 import unittest
 
 from lizrd.support.test_utils import GeneralTestCase
@@ -272,6 +273,7 @@ class LLMTest(GeneralTestCase):
         output_size = 3
         n_blocks = 2
         device = torch.device("cpu")
+        args = argparse.Namespace(use_ngpt=False)
 
         embedding_layer = llm.EmbeddingLayer(
             llm.PositionalEmbedding(
@@ -300,7 +302,16 @@ class LLMTest(GeneralTestCase):
             init_type="kaiming_uniform",
             init_scale=1.0,
         )
-        model = llm.LLM(embedding_layer, encoder_tower, head)
+        model = llm.LLM(
+            embedding_layer,
+            encoder_tower,
+            head,
+            dmodel=dm,
+            vocab_size=vocab_size,
+            use_ngpt=args.use_ngpt,
+            args=args,
+        )
+
         input = torch.randint(0, vocab_size, (batch, seql))
         output = model(input)
         self.assertShape(output, (batch, seql, output_size))
@@ -311,6 +322,7 @@ class LLMTest(GeneralTestCase):
         output_size = 3
         n_blocks = 2
         device = torch.device("cpu")
+        args = argparse.Namespace(use_ngpt=False)
 
         embedding_layer = llm.EmbeddingLayer(
             llm.PositionalEmbedding(
@@ -337,13 +349,17 @@ class LLMTest(GeneralTestCase):
         head = llm.PredictionHead(
             dm, output_size, init_type="kaiming_uniform", init_scale=1.0
         )
-
-        model = llm.LLM(embedding_layer, encoder_tower, head)
-
+        model = llm.LLM(
+            embedding_layer,
+            encoder_tower,
+            head,
+            dmodel=dm,
+            vocab_size=vocab_size,
+            use_ngpt=args.use_ngpt,
+            args=args,
+        )
         input = torch.randint(0, vocab_size, (batch, seql))
-
         output = model(input)
-
         self.assertShape(output, (batch, seql, output_size))
 
 

--- a/research/conditional/utils/argparse.py
+++ b/research/conditional/utils/argparse.py
@@ -524,4 +524,29 @@ def introduce_parser_arguments(
         help="Single GPU FLOPS, default a100 - Tensor Float32(TF32) 156 TFLOPS",
     )
 
+    # nGPT arguments
+    parser.add_argument("--use_ngpt", action="store_true", help="Use nGPT model")
+    parser.add_argument(
+        "--alpha_a", type=float, default=0.05, help="Eigen learning rate for attention"
+    )
+    parser.add_argument(
+        "--alpha_m", type=float, default=0.05, help="Eigen learning rate for MLP"
+    )
+    parser.add_argument(
+        "--s_qk_init", type=float, default=1.0, help="Initial value for s_qk"
+    )
+    parser.add_argument(
+        "--s_u_init", type=float, default=1.0, help="Initial value for s_u"
+    )
+    parser.add_argument(
+        "--s_v_init", type=float, default=1.0, help="Initial value for s_v"
+    )
+    parser.add_argument(
+        "--s_z_init", type=float, default=1.0, help="Initial value for s_z"
+    )
+    parser.add_argument("--s_qk_scale", type=float, default=None, help="Scale for s_qk")
+    parser.add_argument("--s_u_scale", type=float, default=1.0, help="Scale for s_u")
+    parser.add_argument("--s_v_scale", type=float, default=None, help="Scale for s_v")
+    parser.add_argument("--s_z_scale", type=float, default=None, help="Scale for s_z")
+
     return parser

--- a/research/conditional/utils/conditional_trainer.py
+++ b/research/conditional/utils/conditional_trainer.py
@@ -104,6 +104,7 @@ class ConditionalTrainer:
     loaded_training_loop_accumulators: dict = None
     model_active_params: int = 1
     gpu_flops: int = 1
+    after_step_callback: Optional[Callable] = None
 
     def __attrs_post_init__(self):
         if self.mixed_precision_dtype == torch.float16:
@@ -368,6 +369,8 @@ class ConditionalTrainer:
         if self.global_rank is not None:
             dist.all_reduce(torch.tensor(loss, device="cuda"), op=dist.ReduceOp.AVG)
         self._apply_gradient()
+        if self.after_step_callback:
+            self.after_step_callback(self.model)
         self.other_training_states["step_fb_time_acc_sec"] += time() - fb_start
 
         if self.is_logging_process:

--- a/submit_moe_ngpt_job.sh
+++ b/submit_moe_ngpt_job.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#SBATCH --job-name=moe_85M_33B_E16_G4_repro
+#SBATCH --nodes=4
+#SBATCH --gpus-per-node=8
+#SBATCH --ntasks-per-node=8
+#SBATCH --time=168:00:00
+#SBATCH --output=logs/%j.out
+#SBATCH --error=logs/%j.err
+
+# Load necessary modules
+module load cuda/11.7
+
+# Create logs directory
+mkdir -p logs
+
+# Set environment variables
+export MASTER_ADDR=$(scontrol show hostname ${SLURM_NODELIST} | head -n 1)
+export MASTER_PORT=$((29500 + RANDOM % 1000))
+export WORLD_SIZE=$((SLURM_NNODES * SLURM_NTASKS_PER_NODE))
+
+# Use shared file system for HuggingFace cache
+export HF_DATASETS_CACHE=/scratch/shared/datasets/c4
+export HF_HOME=/scratch/shared/datasets/c4
+export TRANSFORMERS_CACHE=/scratch/shared/datasets/c4
+
+echo "Using shared dataset cache at: $HF_DATASETS_CACHE"
+
+# Run with explicit Python environment
+srun bash -c "
+    cd /home/lucas/ceramic-fine-grained-moe && \
+    source venv/bin/activate && \
+    export PYTHONPATH=/home/lucas/ceramic-fine-grained-moe:\$PYTHONPATH && \
+    export HF_DATASETS_CACHE=/scratch/shared/datasets/c4 && \
+    export HF_HOME=/scratch/shared/datasets/c4 && \
+    export TRANSFORMERS_CACHE=/scratch/shared/datasets/c4 && \
+    export RANK=\$SLURM_PROCID && \
+    export LOCAL_RANK=\$SLURM_LOCALID && \
+    python3 research/conditional/train/cc_train.py \
+        --use_ngpt \
+        --model_type gpt \
+        --n_blocks 12 \
+        --dmodel 768 \
+        --dff 3072 \
+        --effective_dff_x 4 \
+        --n_att_heads 12 \
+        --scheduler cosine \
+        --learning_rate 0.0002 \
+        --init_type truncated_normal \
+        --init_scale 0.1 \
+        --dataset_type c4 \
+        --batch_size 2048 \
+        --cutoff 256 \
+        --logger_types wandb \
+        --name moe_85M_33B_E16_G4_repro \
+        --n_gpus 32 \
+        --n_nodes 4 \
+        --n_steps 63000 \
+        --lr_warmup_steps 0 \
+        --final_lr_step 63000 \
+        --final_lr_fraction 0.1 \
+        --grad_clip 0.5 \
+        --weight_decay 0.0 \
+        --ff_mode expert_choice \
+        --softmax_over experts \
+        --layer_norm_in_expert_choice \
+        --group_granular_moe_by_batch \
+        --use_torch_bmm \
+        --granular_moe_one_hot_impl \
+        --expansion_rate 16 \
+        --granularity 4 \
+        --fsdp_enabled \
+        --mixed_precision \
+        --mixed_precision_dtype bfloat16 \
+        --flash_attention \
+        --fsdp_modules_to_wrap 'TransformerBlock,EmbeddingLayer,PredictionHead' \
+        --activation_checkpointing_modules 'TransformerBlock,EmbeddingLayer,PredictionHead' \
+        --wandb_entity ceramicai \
+        --wandb_project fine-grained-moe \
+        --tags moe_baseline reproduction 85M 33B_tokens E16 G4 \
+        --save_weights_path model_checkpoints \
+        --save_weights_interval 5000 \
+        --num_workers 4 \
+        --gradient_accumulation_steps 1 \
+        --logging_interval_loss 1000 \
+        --logging_interval_heavy 5000 \
+        --eval_interval 1000 \
+        --n_eval_batches 200 \
+        --decoding_interval 0 \
+        --project_name fine-grained-moe
+"

--- a/submit_moe_ngpt_torchrun.sh
+++ b/submit_moe_ngpt_torchrun.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# This script can be run in two modes:
+# 1. Master Mode: Run on the master node to launch training on all nodes.
+#    Usage: bash launch_distributed.sh --master_addr <MASTER_IP>
+#
+# 2. Worker Mode: This mode is triggered via SSH by the master. You don't run this manually.
+WORKER_NODES=("worker-ip-1" "worker-ip-2" "worker-ip-3")
+SSH_USER="lucas"
+GPUS_PER_NODE=8
+MASTER_ADDR=""
+MASTER_PORT=29500
+NODE_RANK=-1
+NNODES=-1
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --master_addr) MASTER_ADDR="$2"; shift ;;
+        --node_rank) NODE_RANK="$2"; shift ;;
+        --nnodes) NNODES="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+if [[ "$NODE_RANK" -eq -1 ]]; then
+    echo "--- MASTER MODE: Launching distributed training ---"
+    if [[ -z "$MASTER_ADDR" ]]; then
+        echo "Error: Master IP address must be provided using --master_addr"
+        exit 1
+    fi
+    NNODES=$(( ${#WORKER_NODES[@]} + 1 ))
+    NGPUS=$(( NNODES * GPUS_PER_NODE ))
+    echo "Detected $NNODES total nodes and $NGPUS total GPUs."
+    WORKER_RANK=1
+    for WORKER_IP in "${WORKER_NODES[@]}"; do
+        echo "Launching on worker node $WORKER_RANK ($WORKER_IP)..."
+        ssh -n "$SSH_USER@$WORKER_IP" "bash $(realpath $0) --master_addr $MASTER_ADDR --node_rank $WORKER_RANK --nnodes $NNODES" &
+        ((WORKER_RANK++))
+    done
+    NODE_RANK=0    
+    echo "Launching on master node 0 ($MASTER_ADDR)..."
+else
+    echo "--- WORKER MODE (Rank $NODE_RANK): Starting training process ---"
+    NGPUS=$(( NNODES * GPUS_PER_NODE ))
+fi
+
+cd /home/lucas/ceramic-fine-grained-moe
+source venv/bin/activate
+export PYTHONPATH="/home/lucas/ceramic-fine-grained-moe:$PYTHONPATH"
+export HF_DATASETS_CACHE=/ephemeral/datasets/c4
+export HF_HOME=/ephemeral/datasets/c4
+export TRANSFORMERS_CACHE=/ephemeral/datasets/c4
+
+echo "Starting torchrun on node $NODE_RANK of $NNODES (Total GPUs: $NGPUS)..."
+echo "Master Address: $MASTER_ADDR:$MASTER_PORT"
+
+torchrun \
+    --nproc_per_node $GPUS_PER_NODE \
+    --nnodes $NNODES \
+    --node_rank $NODE_RANK \
+    --master_addr $MASTER_ADDR \
+    --master_port $MASTER_PORT \
+    research/conditional/train/cc_train.py \
+        --use_ngpt \
+        --model_type gpt \
+        --n_blocks 12 \
+        --dmodel 768 \
+        --dff 3072 \
+        --effective_dff_x 4 \
+        --n_att_heads 12 \
+        --scheduler cosine \
+        --learning_rate 0.0002 \
+        --init_type truncated_normal \
+        --init_scale 0.1 \
+        --dataset_type c4 \
+        --batch_size 2048 \
+        --cutoff 256 \
+        --logger_types wandb \
+        --name moe_85M_33B_E16_G4_repro \
+        --n_gpus "$NGPUS" \
+        --n_nodes "$NNODES" \
+        --n_steps 63000 \
+        --lr_warmup_steps 0 \
+        --final_lr_step 63000 \
+        --final_lr_fraction 0.1 \
+        --grad_clip 0.5 \
+        --weight_decay 0.0 \
+        --ff_mode expert_choice \
+        --softmax_over experts \
+        --layer_norm_in_expert_choice \
+        --group_granular_moe_by_batch \
+        --use_torch_bmm \
+        --granular_moe_one_hot_impl \
+        --expansion_rate 16 \
+        --granularity 4 \
+        --fsdp_enabled \
+        --mixed_precision \
+        --mixed_precision_dtype bfloat16 \
+        --flash_attention \
+        --fsdp_modules_to_wrap 'TransformerBlock,EmbeddingLayer,PredictionHead' \
+        --activation_checkpointing_modules 'TransformerBlock,EmbeddingLayer,PredictionHead' \
+        --wandb_entity ceramicai \
+        --wandb_project fine-grained-moe \
+        --tags moe_baseline reproduction 85M 33B_tokens E16 G4 \
+        --save_weights_path model_checkpoints \
+        --save_weights_interval 5000 \
+        --num_workers 4 \
+        --gradient_accumulation_steps 1 \
+        --logging_interval_loss 1000 \
+        --logging_interval_heavy 5000 \
+        --eval_interval 1000 \
+        --n_eval_batches 200 \
+        --decoding_interval 0 \
+        --project_name fine-grained-moe


### PR DESCRIPTION
# Description
This pull request integrates the Normalized Transformer (nGPT) architecture with the existing Fine-Grained Mixture of Experts (MoE) model. The goal is to leverage the faster convergence and improved stability of nGPT's hyperspherical representation learning within our MoE framework.

All nGPT-related logic is controlled by a `--use_ngpt` command-line flag, ensuring full backward compatibility with the existing dense and MoE models.

## Key Changes
* Added new classes: `NgptBlock`, `NgptAttention`, and `NgptFeedForward` to implement the core normalization and update logic.
* Modified the main LLM class to conditionally handle nGPT's unique final layer requirements (initial embedding normalization, no final RMSNorm, and learnable logit scaling)
* The optimizer creation in `cc_train.py` now disables weight_decay for nGPT models.
* The `ConditionalTrainer` now supports an `after_step_callback` to perform nGPT's mandatory parameter normalization after each optimizer step
* Added new command-line arguments to control the nGPT architecture, including `--use_ngpt` and hyperparameters for eigen learning rates and scaling factors
* Updated unit tests to be compatible with the modified LLM class constructor, ensuring all tests pass
* Added a new `launch_distributed.sh` script for automated, multi-node distributed training using `torchrun`, replacing the previous SLURM-specific setup. We will be returning the Crusoe cluster by the time I train this model

See [nGPT paper](https://arxiv.org/pdf/2410.01131) for more details.



